### PR TITLE
Make Q escape on tap (still 小-shift when held)

### DIFF
--- a/include/zmk_naginata/naginata_func.h
+++ b/include/zmk_naginata/naginata_func.h
@@ -10,6 +10,7 @@ void input_unicode_hex(int, int, int, int);
 
 void ng_T(void);
 void ng_Y(void);
+void ng_Q(void);
 void ng_ST(void);
 void ng_SY(void);
 void ngh_JKQ(void);

--- a/src/behaviors/behavior_naginata.c
+++ b/src/behaviors/behavior_naginata.c
@@ -275,7 +275,7 @@ static naginata_kanamap ngdickana[] = {
     // 追加
     {.shift = NONE    , .douji = B_SPACE        , .kana = {SPACE, NONE, NONE, NONE, NONE, NONE  }, .func = nofunc},
     {.shift = B_SPACE , .douji = B_V            , .kana = {COMMA, ENTER, NONE, NONE, NONE, NONE }, .func = nofunc},
-    {.shift = NONE    , .douji = B_Q            , .kana = {NONE, NONE, NONE, NONE, NONE, NONE   }, .func = nofunc},
+    {.shift = NONE    , .douji = B_Q            , .kana = {NONE, NONE, NONE, NONE, NONE, NONE   }, .func = ng_Q},
     {.shift = B_SPACE , .douji = B_M            , .kana = {DOT, ENTER, NONE, NONE, NONE, NONE   }, .func = nofunc},
     {.shift = NONE    , .douji = B_U            , .kana = {BSPC, NONE, NONE, NONE, NONE, NONE   }, .func = nofunc},
 

--- a/src/naginata_func.c
+++ b/src/naginata_func.c
@@ -163,6 +163,11 @@ void ng_T() { ng_left(1); }
 
 void ng_Y() { ng_right(1); }
 
+void ng_Q() {
+    raise_zmk_keycode_state_changed_from_encoded(ESCAPE, true, timestamp);
+    raise_zmk_keycode_state_changed_from_encoded(ESCAPE, false, timestamp);
+}
+
 void ng_ST() {
     raise_zmk_keycode_state_changed_from_encoded(LSHIFT, true, timestamp);
     ng_left(1);


### PR DESCRIPTION
This should be useful on macOS or Windows (and probably Linux) during kanji selection (see issue #3).

According to the [Apple Japanese input method documentation](https://support.apple.com/en-gb/guide/japanese-input-method/jpim10263/mac) both macOS and Windows use Escape for:

* Revert back to yomi while still selecting a kanji (before conversion)
* Delete all text that is considered for conversion

Also potentially useful more generally on 36-key or similar small keyboards where Qwerty Q is top left like escape on a full sized keyboard.

If you like this idea, we could suggest it to Ōoka-san for Naginata Style v17?